### PR TITLE
Add google analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,9 @@ tagline:          ''
 description:      ''
 url:              atxopendata.rocks
 
+# Google Analytics
+google_analytics: UA—XXXXXXXX-X
+
 author:
   name:           ''
   url:            ''

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,0 +1,5 @@
+<script>
+    window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+    ga('create', '{{ site.google_analytics }}', 'auto');
+    ga('send', 'pageview');
+    

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -59,3 +59,9 @@
 <!-- CSS
 ================================================== -->
   <link rel="stylesheet" href="{{ "/assets/css/main.css" | prepend: site.baseurl }}">
+
+<!--->Google Analytics
+================================================== -->
+{% if site.google_analytics and jekyll.environment == 'production' %}
+{% include analytics.html %}
+{% endif %}


### PR DESCRIPTION
I updated the code base to add google analytics. 

I used these instructions for adding ga to jeckyl static pages: 
https://desiredpersona.com/google-analytics-jekyll/

I haven't tested because you need to add your analytics trackingid to _config.yml 
Analytics setup instructions are here:
https://marketingplatform.google.com/about/analytics/